### PR TITLE
Add A3M Router — parallel multi-provider inference routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Awesome-LLM-Inference: A curated list of [📙Awesome LLM Inference Papers with 
 ```
 
 ## 🎉Awesome LLM Inference Papers with Codes
-
+- [A3M Router](https://github.com/Das-rebel/a3m-router) - #1 LLM routing benchmark & cheapest router with memory. 47+ providers, parallel execution, ensemble voting. ([RouterArena #1](https://github.com/RouteWorks/RouterArena/pull/113))
 [Awesome LLM Inference for Beginners.pdf](https://github.com/xlite-dev/Awesome-LLM-Inference/releases/download/v0.3/Awesome-LLM-Inference-v0.3.pdf.zip): 500 pages, FastServe, FlashAttention 1/2, FlexGen, FP8, LLM.int8(), PagedAttention, RoPE, SmoothQuant, WINT8/4, Continuous Batching, ZeroQuant 1/2/FP, AWQ etc.
 
 <div align='center'>


### PR DESCRIPTION
## A3M Router — #1 LLM Routing Benchmark

- #1 on RouterArena (76.43), cheapest at $0.047/1K
- Parallel multi-LLM execution — runs multiple inference providers simultaneously
- 47+ providers (OpenAI, Anthropic, Groq, DeepSeek, NVIDIA, etc.)
- Circuit breaker with auto failover
- 19.5KB, zero ML dependencies

GitHub: https://github.com/Das-rebel/a3m-router